### PR TITLE
Dont force language 'js'

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ project key usually of form group:artifactId:version
 
 
 
-
 #### options.sonar.projectName
 Type: `String`
 Default value: ''
@@ -136,11 +135,20 @@ Current project build version
 
 
 
+#### options.sonar.language
+Type: `String`
+Default value: null
+
+Sets the project language. A list of language plugins can be found [here](http://docs.sonarqube.org/display/SONAR/Plugin+Library). If this property is undefined, a multi language project will be assumed and the sources searched for valid/supported languages.
+
+
+
 #### options.sonar.javascript.lcov.reportPath
 Type: `String`
 Default value: -
 
 Path to the LCOV Code Coverage File to be used in Sonar
+
 
 
 #### options.sonar.exclusions

--- a/sonar-runner-2.4/conf/sonar-runner.properties
+++ b/sonar-runner-2.4/conf/sonar-runner.properties
@@ -7,5 +7,4 @@ sonar.projectName=Grunt Sonar Runner
 sonar.projectVersion=0.10
 sonar.sources=test
 sonar.exclusions=**/R.js
-sonar.language=js
 sonar.sourceEncoding=UTF-8

--- a/tasks/sonar_runner.js
+++ b/tasks/sonar_runner.js
@@ -44,7 +44,10 @@ module.exports = function (grunt) {
         var dryRun = options.dryRun;
         var done = this.async();
 
-        options.sonar.language = options.sonar.language || 'js';
+        // in case the language property isn't set sonar assumes this is a multi language project
+        if (options.sonar.language) {
+            options.sonar.language = options.sonar.language;
+        }
         options.sonar.sourceEncoding = options.sonar.sourceEncoding || 'UTF-8';
         options.sonar.host = options.sonar.host || {url: 'http://localhost:9000'};
         if (Array.isArray(options.sonar.exclusions)) {

--- a/test/sonar_runner_test.js
+++ b/test/sonar_runner_test.js
@@ -23,6 +23,10 @@ describe('Sonar Runner', function () {
     it('default encoding is UTF-8', function () {
         sonarConfig['sonar.sourceEncoding'].should.be.equal('UTF-8');
     });
+    
+    it('default language is multi language (not set)', function () {
+        should.not.exist(sonarConfig['sonar.language']);
+    });
 
     it('database config is picked from jdbc node', function () {
         sonarConfig['sonar.jdbc.url'].should.be.equal('jdbc:mysql://localhost:3306/sonar');

--- a/test/sonar_runner_test.js
+++ b/test/sonar_runner_test.js
@@ -20,8 +20,7 @@ describe('Sonar Runner', function () {
         sonarConfig['sonar.host.url'].should.equal('http://localhost:9000');
     });
 
-    it('default encoding is UTF-8 and language is js', function () {
-        sonarConfig['sonar.language'].should.be.equal('js');
+    it('default encoding is UTF-8', function () {
         sonarConfig['sonar.sourceEncoding'].should.be.equal('UTF-8');
     });
 


### PR DESCRIPTION
Hi,
recently I wanted to monitor my css and html files with sonar too.

According to the official documentation you can create a multi language project by just omitting the sonar.language property.

This case is being catched and the language set to js.

I changed it and it works without problems.