### PR TITLE
Check sonar runner exists in envirnment

### DIFF
--- a/tasks/sonar_runner.js
+++ b/tasks/sonar_runner.js
@@ -11,7 +11,7 @@
 var childProcess = require('child_process'), format = require('util').format, os = require('os');
 
 module.exports = function (grunt) {
-    var SONAR_RUNNER_HOME = __dirname+'/../sonar-runner-2.4';
+    var SONAR_RUNNER_HOME = process.env.SONAR_RUNNER_HOME || __dirname+'/../sonar-runner-2.4';
 
     var JAR = '/lib/sonar-runner-dist-2.4.jar';
     var SONAR_RUNNER_COMMAND = 'java -jar ' + SONAR_RUNNER_HOME + JAR+' -X -Drunner.home=' + SONAR_RUNNER_HOME;


### PR DESCRIPTION
If sonar runner exists then use that or falls back to bundled sonar
runner. I am using Go build server and can't execute JAR file which is bundle with the module. So this change checks sonar runner env variable exits and if so then use that one