### PR TITLE
fix repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
         "name": "Suresh Khatri",
         "email": "servlet2@msn.com"
     },
-    "repository": {
-        "type": "git",
-        "url": "git@github.com/skhatri/grunt-sonar-runner.git"
-    },
+    "repository": "skhatri/grunt-sonar-runner",
     "bugs": {
         "url": "https://github.com/skhatri/grunt-sonar-runner/issues"
     },


### PR DESCRIPTION
The link to the repository is wrong on the [npm package page](https://www.npmjs.com/package/grunt-sonar-runner).

As the project is hosted on GitHub you can omit the repository type.