### PR TITLE
Enabled plugin to work with grunt 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
         "test": "grunt test"
     },
     "devDependencies": {
-        "grunt-contrib-jshint": "~0.10.0",
-        "grunt-contrib-clean": "~0.6.0",
-        "grunt": ">=0.4.5",
-        "grunt-mocha-test": "~0.12.4",
-        "should":"~4.4.1"
+        "grunt": "^1.0.1",
+        "grunt-contrib-clean": "^1.0.0",
+        "grunt-contrib-jshint": "^1.0.0",
+        "grunt-mocha-test": "^0.12.4",
+        "should": "^9.0.0"
     },
     "peerDependencies": {
-        "grunt": "~0.4.5"
+        "grunt": ">=0.4.5"
     },
     "keywords": [
         "gruntplugin", "sonar", "sonar-runner"


### PR DESCRIPTION
Updated dependencies and listed the peerDependencies based on the recommendations to allow the plugin to work with npm 2

This pull request fixes #23