### PR TITLE
Fix execution when sonar-runner path contains spaces

### DIFF
--- a/tasks/sonar_runner.js
+++ b/tasks/sonar_runner.js
@@ -14,9 +14,9 @@ module.exports = function (grunt) {
     var SONAR_RUNNER_HOME = process.env.SONAR_RUNNER_HOME || __dirname+'/../sonar-runner-2.4';
     var SONAR_RUNNER_OPTS = process.env.SONAR_RUNNER_OPTS || "";
 
-    var JAR = '/lib/sonar-runner-dist-2.4.jar';
-    var SONAR_RUNNER_COMMAND = 'java ' + SONAR_RUNNER_OPTS + ' -jar ' + SONAR_RUNNER_HOME + JAR+' -Drunner.home=' + SONAR_RUNNER_HOME;        
-    var LIST_CMD = (/^win/).test(os.platform()) ? 'dir '+SONAR_RUNNER_HOME + JAR : 'ls '+SONAR_RUNNER_HOME + JAR;
+    var JAR = SONAR_RUNNER_HOME + '/lib/sonar-runner-dist-2.4.jar';
+    var SONAR_RUNNER_COMMAND = 'java ' + SONAR_RUNNER_OPTS + ' -jar "' + JAR + '" -Drunner.home="' + SONAR_RUNNER_HOME + '"';
+    var LIST_CMD = (/^win/).test(os.platform()) ? 'dir "' + JAR + '"' : 'ls "' + JAR + '"';
 
     var mergeOptions = function (prefix, effectiveOptions, obj) {
         for (var j in obj) {


### PR DESCRIPTION
Otherwise the following occurs:
```
Running "sonarRunner:analysis" (sonarRunner) task
sonar-runner exec: java  -jar /var/lib/jenkins/workspace/myclient (master)/node_modules/grunt-sonar-runner/tasks/../sonar-runner-2.4/lib/sonar-runner-dist-2.4.jar -Drunner.home=/var/lib/jenkins/workspace/myclient (master)/node_modules/grunt-sonar-runner/tasks/../sonar-runner-2.4
>> /bin/sh: -c: line 0: syntax error near unexpected token `('
>> /bin/sh: -c: line 0: `java  -jar /var/lib/jenkins/workspace/myclient (master)/node_modules/grunt-sonar-runner/tasks/../sonar-runner-2.4/lib/sonar-runner-dist-2.4.jar -Drunner.home=/var/lib/jenkins/workspace/myclient (master)/node_modules/grunt-sonar-runner/tasks/../sonar-runner-2.4'
>> Return code: 1.
Warning: Task "sonarRunner:analysis" failed. Use --force to continue.
```